### PR TITLE
SimpleTemplateMatching -- make matcher public

### DIFF
--- a/src/boofcv/processing/SimpleTemplateMatching.java
+++ b/src/boofcv/processing/SimpleTemplateMatching.java
@@ -16,7 +16,7 @@ import java.util.List;
  */
 public class SimpleTemplateMatching {
 
-    TemplateMatching<GrayU8> matcher;
+    public TemplateMatching<GrayU8> matcher;
 
     GrayU8 ginput = new GrayU8(1,1);
     GrayU8 gtemplate = new GrayU8(1,1);


### PR DESCRIPTION
This is the simplest possible change to make template matching usable by exposing scores.